### PR TITLE
docs: collapse the four Utilities rows in the migration table into one

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -148,9 +148,6 @@ if err != nil {
 | N/A | `client.Stocks.Prices(ctx, syms)` | New in v2 |
 | N/A | `client.Markets.StatusHistory(ctx)` | New in v2 |
 | N/A | `client.Utilities.Status/Headers/User(ctx)` | New in v2 (v1 had no Utilities resource) |
-| N/A | `client.Utilities.Status(ctx)` | New in v2 |
-| N/A | `client.Utilities.Headers(ctx)` | New in v2 |
-| N/A | `client.Utilities.User(ctx)` | New in v2 |
 
 ### Removed from v2
 


### PR DESCRIPTION
The migration table listed `client.Utilities.Status/Headers/User(ctx)` as one row and then repeated each of the three methods as its own row directly beneath it, all with the same "New in v2" note.

Keeps the combined row, which carries the useful detail (v1 had no Utilities resource), and drops the three that repeat it.

Docs only — 3 deletions, no code touched.