### PR TITLE
ci: add release automation — tag-and-release.yml and RELEASE_PROCESS.md

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -1,0 +1,182 @@
+# Go SDK Release Process
+
+This document defines the release process for `MarketDataApp/sdk-go`. The module is
+[`github.com/MarketDataApp/sdk-go/v2`](https://pkg.go.dev/github.com/MarketDataApp/sdk-go/v2).
+
+## 1. What "publishing" means for Go
+
+There is no package registry. The other Market Data SDKs push a built artifact to npm,
+PyPI, Maven Central, NuGet or Packagist. Go has none of that:
+[proxy.golang.org](https://proxy.golang.org) clones the repository and reads the git tag
+the first time anyone asks for a version.
+
+**The tag is the publication.** Nothing is uploaded. That has three consequences that
+shape everything below.
+
+| | |
+|---|---|
+| **Publishing is instant** | The moment `v2.0.1` exists and one person fetches it, it is public. |
+| **Publishing is irreversible** | The proxy is append-only and `sum.golang.org` records the hash in a transparency log. Deleting the tag on GitHub does **not** withdraw the version. |
+| **Validation must happen before the tag** | There is no "unlist", no staging feed, and no window in which to reconsider. |
+
+The only remedy for a bad release is to publish a later version that
+[`retract`](https://go.dev/ref/mod#go-mod-file-retract)s it. The bad version stays
+downloadable forever; `retract` only stops the toolchain from selecting it.
+
+## 2. Scope and versioning
+
+`2.0.0` is published. The public API is covered by semantic versioning from that version
+on, so the version number is a promise:
+
+| Change | Version |
+|---|---|
+| Bug fix, no API change | `2.0.Z` |
+| New API, nothing removed or altered | `2.Y.0` |
+| Anything a caller must react to | `3.0.0` |
+
+Removing an exported identifier, renaming one, changing a signature, tightening a return
+type, or altering documented behaviour all count.
+
+> **A major bump is expensive in Go.** From v2 onward the major version lives in the
+> module path itself. `3.0.0` means editing `go.mod` to
+> `github.com/MarketDataApp/sdk-go/v3`, rewriting every internal import, and leaving v2
+> users on a path that never receives the change. Treat a major bump as a fork of the
+> import path, not as a version number.
+>
+> The release workflow refuses a version whose major disagrees with the module path, so
+> dispatching `3.0.0` against a `/v2` module fails in the first job rather than cutting an
+> unusable tag.
+
+## 3. Release preparation
+
+1. Confirm `main` is current and CI is green for the commit you intend to release.
+
+2. **Promote the CHANGELOG section.** `CHANGELOG.md` is the single source of truth for
+   release notes. In a normal PR:
+
+   - Change `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`.
+   - Add a fresh, empty `## [Unreleased]` section above it.
+   - Update the link-reference block at the bottom of the file: point `[Unreleased]` at
+     `compare/vX.Y.Z...HEAD` and add an `[X.Y.Z]` entry.
+   - Confirm every breaking change has migration guidance in `docs/MIGRATION.md`.
+
+   > **The release workflow matches `## [X.Y.Z]` exactly** (Keep a Changelog bracket
+   > format). A `## vX.Y.Z` heading will not be found, and the release fails in the
+   > `validate` job before any tag is created.
+
+3. Confirm `README.md` and `docs/` describe the behaviour you are about to ship.
+
+4. Merge that PR to `main`.
+
+## 4. Cut the release
+
+One workflow drives the whole release: **Tag and Release**
+(`.github/workflows/tag-and-release.yml`). Go to Actions → "Tag and Release" → "Run
+workflow", and fill in:
+
+| Input | Value |
+|---|---|
+| **version** | `X.Y.Z` (no `v` prefix) |
+| **ref** | `main` (or a specific commit SHA) |
+| **prerelease** | `false` unless this is a prerelease |
+| **confirm** | `RELEASE` exactly |
+
+Nothing else triggers this workflow. Pushing commits, merging PRs and pushing branches
+never reach it.
+
+The run proceeds through four gated stages. Each must pass before the next starts.
+
+1. **`validate`** — seconds, and deliberately first so a typo costs no runner time. Checks
+   that `confirm` is exactly `RELEASE`, that the version is semver without a `v` prefix,
+   that the major agrees with the module path in `go.mod`, that the tag does not already
+   exist on origin, and that `CHANGELOG.md` has a `## [X.Y.Z]` section. It prints the
+   release notes it extracted so you can read them in the log before anything happens.
+
+2. **`gate`** — calls `tests.yml`, the ordinary CI suite, against the exact ref: unit
+   tests on Go 1.22 and stable, the 100% coverage gate, lint, `govulncheck`, the
+   negative-compile corpus, the three example apps, and the **live integration suite**.
+   The suite is called, not copied, so the release gate and everyday CI can never drift
+   apart.
+
+   > Integration is forced on. On an ordinary push `tests.yml` skips it; a release is
+   > exactly the moment it must not be skipped. A missing `MARKETDATA_TOKEN` fails the
+   > release rather than quietly reporting a suite that ran nothing.
+
+3. **`release`** — **the point of no return.** Resolves `ref` to a concrete SHA, re-checks
+   that the tag still does not exist, re-extracts the CHANGELOG section, then creates the
+   tag and the GitHub Release `vX.Y.Z` pointing at that SHA.
+
+4. **`verify`** — polls `proxy.golang.org` until it serves the new version (the first
+   request is what makes the proxy fetch it), then creates a throwaway module, resolves
+   the SDK from the public proxy, and asserts `marketdata.Version()` reports the version
+   just released. Before the tag existed that call returned `unknown`, so this genuinely
+   proves the published module, not the local checkout.
+
+### Why no workflow run appears for the release
+
+`tests.yml` has a `release: published` trigger, and it stays silent here. GitHub does not
+start a workflow run from an event raised by the default `GITHUB_TOKEN`, as a guard
+against recursive triggering.
+
+That is fine and intended: the `gate` job already ran that same suite against the same
+commit, minutes earlier. Do not "fix" the silent trigger by re-running tests after the
+tag — by then the version is public, so a failure would be a discovery, not a gate.
+
+### The CHANGELOG is written by hand, never by a workflow
+
+There is deliberately no workflow that writes back to `CHANGELOG.md`. Promote
+`## [Unreleased]` yourself in the release PR, as §3 describes. That is the only supported
+path.
+
+## 5. Post-release checks
+
+The `verify` job already proves the first two. Check the rest by hand.
+
+1. The GitHub Release exists with the notes taken from `CHANGELOG.md`.
+2. A clean module resolves it:
+
+   ```bash
+   cd "$(mktemp -d)" && go mod init smoke
+   go get github.com/MarketDataApp/sdk-go/v2@vX.Y.Z
+   ```
+
+3. `https://pkg.go.dev/github.com/MarketDataApp/sdk-go/v2@vX.Y.Z` renders the godoc.
+   pkg.go.dev indexes asynchronously and can lag the proxy by up to an hour; a 404 shortly
+   after a release is normal and needs no action.
+4. `go get github.com/MarketDataApp/sdk-go` (no `/v2`) still resolves to `v1.2.0`. The v1
+   line is served from the `v1` branch and the immutable `v1.2.0` tag, and no v2 release
+   should ever disturb it.
+
+## 6. Rollback and hotfix
+
+A published version cannot be replaced, unpublished, or hidden.
+
+1. Stop any promotion messaging.
+2. Ship a patch release `vX.Y.(Z+1)` from `main` with the targeted fix, through the normal
+   process above.
+3. If the bad version is actively harmful, add a `retract` block to `go.mod` in that patch
+   release so the toolchain stops selecting it:
+
+   ```go
+   retract (
+       v2.0.1 // Published in error: <reason>.
+   )
+   ```
+
+   `retract` is advisory. It stops `go get` from *choosing* the version; anyone who pins it
+   explicitly still gets it, and the module cache and proxy keep serving it forever.
+4. Record the root cause and the remediation in the next `CHANGELOG.md` entry.
+
+## 7. Repository state this process assumes
+
+| Item | State |
+|---|---|
+| `MARKETDATA_TOKEN` secret | required — the release gates on the live integration suite |
+| `CODECOV_TOKEN` secret | optional; its absence leaves the coverage badge empty and breaks nothing |
+| `main` branch protection | none at time of writing; the `confirm: RELEASE` input and the gated stages are the controls |
+| `v1` branch | must never be deleted — it is what keeps the v1 line browsable |
+| `v1.2.0` tag | must never be moved or deleted — it is what keeps v1 installable |
+
+> **Never create another repository named `sdk-go` under the `MarketDataApp` account.**
+> The module path is frozen at `github.com/MarketDataApp/sdk-go/v2`; changing it later
+> would require a v3.

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,369 @@
+name: Tag and Release
+
+# Cuts the git tag and the GitHub Release for a version, then proves the module
+# actually installs from the public proxy. Mirrors the Java and C# SDKs'
+# tag-and-release.yml, minus their publish stage.
+#
+# WHY THERE IS NO PUBLISH STAGE:
+# the other five SDKs push to a package registry — npm, PyPI, Maven Central,
+# NuGet, Packagist. Go has no registry. proxy.golang.org fetches straight from
+# the git tag the first time somebody asks for the version, so **the tag is the
+# publication**. There is nothing to upload, which is why this workflow ends
+# with a verification job instead of a publish job.
+#
+# Nothing here fires on its own: the only trigger is a manual workflow_dispatch
+# that also requires `confirm: RELEASE`. Pushing commits, merging PRs and
+# pushing branches never reach this workflow.
+#
+# Each stage gates the next:
+#   validate -> cheap input and repository checks, seconds, before any runner cost
+#   gate     -> the entire tests.yml suite, integration included, on the exact ref
+#   release  -> tag + GitHub Release, pointing at a resolved SHA
+#   verify   -> proxy serves the version and a scratch module installs it
+#
+# THE POINT OF NO RETURN IS THE `release` JOB. proxy.golang.org is an
+# append-only mirror and sum.golang.org records the hash in a transparency log.
+# Once a version is fetched it can be neither modified nor withdrawn — deleting
+# the tag on GitHub does not retract it. The only remedy is a later version that
+# retracts the bad one. Everything before `release` is reversible; nothing after
+# it is. That is why `validate` and `gate` are exhaustive and run first.
+#
+# CHANGELOG.md is the single source of truth for release notes. The `validate`
+# job requires a `## [X.Y.Z]` section and fails without one, so promote
+# `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` in a normal PR BEFORE running
+# this. See .github/RELEASE_PROCESS.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without the v prefix (example: 2.0.1)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to release (branch, tag, or commit SHA)"
+        required: false
+        default: "main"
+        type: string
+      prerelease:
+        description: "Mark the GitHub Release as a prerelease"
+        required: false
+        default: false
+        type: boolean
+      confirm:
+        description: "Type RELEASE to confirm"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Never cancel a release mid-flight: a cancelled run could leave a tag whose
+# version the proxy has already cached.
+concurrency:
+  group: release-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Check the confirmation and the version string
+        shell: bash
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          test "$CONFIRM" = "RELEASE" || {
+            echo "::error::confirm input must be exactly RELEASE"
+            exit 1
+          }
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
+            echo "::error::version must be semver-like without a v prefix (example: 2.0.1)"
+            exit 1
+          }
+
+      # Go encodes the major version in the module path from v2 onward, so a
+      # mismatch here would publish a version the import path cannot serve:
+      # module .../sdk-go/v2 can only ever produce v2.x.y. Nothing downstream
+      # catches this — the tag would be cut and the proxy would reject or
+      # mis-serve it — so it is checked before anything else runs.
+      - name: Check the version agrees with the module path
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          MODULE=$(go mod edit -json | sed -n 's/.*"Path": "\([^"]*\)".*/\1/p' | head -1)
+          MAJOR="${VERSION%%.*}"
+
+          if [ "$MAJOR" -ge 2 ]; then
+            WANT_SUFFIX="/v${MAJOR}"
+          else
+            WANT_SUFFIX=""
+          fi
+
+          case "$MODULE" in
+            */v[0-9]*) GOT_SUFFIX="/${MODULE##*/}" ;;
+            *)         GOT_SUFFIX="" ;;
+          esac
+
+          if [ "$GOT_SUFFIX" != "$WANT_SUFFIX" ]; then
+            echo "::error::go.mod declares module '${MODULE}', which cannot publish v${VERSION}. A v${MAJOR} release needs the module path to end in '${WANT_SUFFIX}'."
+            exit 1
+          fi
+          echo "module ${MODULE} can publish v${VERSION}"
+
+      - name: Verify the tag does not already exist
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists on origin. Module versions are immutable once the proxy has served them; pick the next patch version instead."
+            exit 1
+          fi
+          echo "${TAG} is free"
+
+      # Checked here, before the expensive gate, so a missing CHANGELOG section
+      # costs seconds rather than a full matrix run. The release job extracts it
+      # again from the resolved SHA when it actually writes the notes.
+      - name: Verify CHANGELOG has a section for this version
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found && /^\[[^]]+\]: / { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No '## [${VERSION}]' section in CHANGELOG.md. Promote '## [Unreleased]' to '## [${VERSION}] - YYYY-MM-DD' first (see .github/RELEASE_PROCESS.md)."
+            exit 1
+          fi
+
+          echo "=== Release notes that will be published ==="
+          cat release-notes.md
+
+  # The release gate is the ordinary CI suite, called rather than copied: unit
+  # tests on Go 1.22 and stable, the 100% coverage gate, lint, govulncheck, the
+  # negative-compile corpus, the three example apps, and the live integration
+  # suite against the real API.
+  #
+  # run_integration is forced true. On a normal push tests.yml skips
+  # integration; a release is exactly the moment it must not be skipped.
+  gate:
+    name: Gate
+    needs: validate
+    uses: ./.github/workflows/tests.yml
+    with:
+      ref: ${{ inputs.ref }}
+      run_integration: true
+    secrets: inherit
+
+  release:
+    name: Tag and GitHub Release
+    needs: [validate, gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # create the tag and the GitHub Release
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      # Resolve the ref to a concrete SHA so the tag and the GitHub Release
+      # describe the SAME commit even if `main` moves during the run.
+      - name: Resolve commit SHA
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Re-checked because `validate` ran minutes ago and someone could have
+      # pushed the tag by hand in between. This is the last gate before the
+      # irreversible step.
+      - name: Verify the tag still does not exist
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} appeared on origin while this run was in flight. Refusing to continue."
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found && /^\[[^]]+\]: / { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No '## [${VERSION}]' section in CHANGELOG.md at ${GITHUB_SHA}."
+            exit 1
+          fi
+
+      # `gh release create` makes the tag and the Release in one call, both
+      # pointing at the resolved SHA.
+      - name: Create the tag and the GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          TARGET_REF: ${{ steps.resolve.outputs.sha }}
+          IS_PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          TAG="v${VERSION}"
+          FLAGS=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            FLAGS="${FLAGS} --prerelease"
+          else
+            FLAGS="${FLAGS} --latest"
+          fi
+
+          gh release create "${TAG}" \
+            --target "${TARGET_REF}" \
+            --title "v${VERSION}" \
+            --notes-file release-notes.md \
+            ${FLAGS}
+
+      # tests.yml has a `release: published` trigger, and it will NOT fire for
+      # this release: GitHub suppresses workflow runs raised by events that the
+      # default GITHUB_TOKEN created, to prevent recursive triggering. That is
+      # deliberate and harmless here — the `gate` job above already ran the same
+      # suite, integration included, against this exact commit. Do not "fix" the
+      # silent trigger by re-running tests after the tag; the gate is the check.
+      - name: Note that the release-triggered run stays silent
+        run: |
+          echo "::notice::v${{ inputs.version }} released at ${{ steps.resolve.outputs.sha }}. The 'release published' trigger in tests.yml does not fire for a GITHUB_TOKEN-created release; the gate job already ran that suite against this commit."
+
+  verify:
+    name: Verify the module publishes
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Checked out only to read the module path out of go.mod, so nothing here
+      # hardcodes "/v2" and a future major version needs no edit.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release.outputs.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "stable"
+          cache: false
+
+      - name: Read the module path
+        id: mod
+        shell: bash
+        run: |
+          MODULE=$(go mod edit -json | sed -n 's/.*"Path": "\([^"]*\)".*/\1/p' | head -1)
+
+          # The proxy lower-cases capitals and prefixes them with "!", so
+          # MarketDataApp becomes !market!data!app.
+          ESCAPED=$(printf '%s' "$MODULE" | sed 's/\([A-Z]\)/!\l\1/g')
+
+          echo "module=${MODULE}"   >> "$GITHUB_OUTPUT"
+          echo "escaped=${ESCAPED}" >> "$GITHUB_OUTPUT"
+          echo "module=${MODULE} escaped=${ESCAPED}"
+
+      # proxy.golang.org fetches a version lazily, on the first request for it.
+      # Until something asks, @v/list keeps omitting it, so this both triggers
+      # the fetch and waits for it to land.
+      - name: Wait for proxy.golang.org to serve the version
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          ESCAPED: ${{ steps.mod.outputs.escaped }}
+        run: |
+          TAG="v${VERSION}"
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS "https://proxy.golang.org/${ESCAPED}/@v/list" | grep -qx "${TAG}"; then
+              echo "proxy is serving ${TAG} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "attempt ${attempt}: ${TAG} not on the proxy yet, waiting 10s"
+            sleep 10
+          done
+
+          echo "::error::proxy.golang.org did not serve ${TAG} within 5 minutes. The tag exists, so the release is real; the proxy may simply be slow. Re-run this job before assuming a failure."
+          exit 1
+
+      # The real proof: a module that has never seen this SDK resolves it from
+      # the public proxy and reports the version it was built from. Before the
+      # tag existed, Version() returned "unknown".
+      - name: Install from scratch and assert the reported version
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          MODULE: ${{ steps.mod.outputs.module }}
+        run: |
+          WORK="$(mktemp -d)"
+          cd "$WORK"
+          go mod init releasecheck
+
+          go get "${MODULE}@v${VERSION}"
+
+          cat > main.go <<EOF
+          package main
+
+          import (
+          	"fmt"
+          	"os"
+
+          	"${MODULE}/marketdata"
+          )
+
+          func main() {
+          	want := os.Args[1]
+          	got := marketdata.Version()
+          	if got != want {
+          		fmt.Printf("Version() = %q, want %q\n", got, want)
+          		os.Exit(1)
+          	}
+          	fmt.Printf("Version() = %s\n", got)
+          }
+          EOF
+
+          go run . "v${VERSION}"
+
+      - name: Summarise
+        env:
+          VERSION: ${{ inputs.version }}
+          MODULE: ${{ steps.mod.outputs.module }}
+        run: |
+          {
+            echo "### v${VERSION} published"
+            echo
+            echo '```'
+            echo "go get ${MODULE}@v${VERSION}"
+            echo '```'
+            echo
+            echo "- Release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}"
+            echo "- Docs: https://pkg.go.dev/${MODULE}@v${VERSION}"
+            echo
+            echo "pkg.go.dev indexes asynchronously and can lag the proxy by up to an hour."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,21 @@ on:
     branches: [main, master, development]
   release:
     types: [published]
+  # Reusable entry point. tag-and-release.yml calls this so the release gate
+  # and ordinary CI are literally the same jobs — there is no second copy of
+  # the suite to drift out of sync.
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to test. Empty means the triggering commit."
+        required: false
+        type: string
+        default: ""
+      run_integration:
+        description: "Run the live integration suite (needs MARKETDATA_TOKEN)."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   unit-tests:
@@ -21,6 +36,8 @@ jobs:
         go-version: ['1.22.x', 'stable']
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -83,6 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -108,6 +127,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -126,12 +147,16 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
-    # Run on releases and all PRs
+    # Run on releases, on all PRs, and whenever a calling workflow asks
+    # (tag-and-release.yml does, so a release is gated on the live API).
     if: |
       github.event_name == 'release' ||
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' ||
+      inputs.run_integration
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -154,6 +179,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -188,6 +215,8 @@ jobs:
         dir: [examples/tuitest, examples/stockterm, examples/optionterm]
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.0.0] - 2026-09-02
 
 Initial v2 release. A complete rewrite of the SDK following idiomatic Go
@@ -459,4 +461,5 @@ patterns; see docs/MIGRATION.md for migrating from v1.
 - Dead exports that no SDK path used: the `UniversalParams` struct (universal parameters are client options), `stocks.formatInt`, and the internal `Tracker.Exceeded`
 - The v1 strikes endpoint has no v2 equivalent (dropped from the required SDK surface); use Chain with strike filters instead
 
+[Unreleased]: https://github.com/MarketDataApp/sdk-go/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/MarketDataApp/sdk-go/releases/tag/v2.0.0


### PR DESCRIPTION
Closes the last gap from the v2 release runbook: Go was the only SDK with no release automation, and v2.0.0 was cut entirely by hand.

## What this is not

The other five SDKs publish to a package registry. Go has none — `proxy.golang.org` reads the git tag, so **the tag is the publication**. There is nothing to upload, so there is no publish stage. In its place the workflow ends with a job that proves the module actually resolves from the public proxy.

## Stages

| Job | Does |
|---|---|
| `validate` | `confirm=RELEASE`, semver, **module-path/major agreement**, tag is free, CHANGELOG section exists — seconds, before any runner cost |
| `gate` | Calls `tests.yml` against the exact ref, with the live integration suite forced on |
| `release` | The point of no return: resolve SHA, re-check the tag, extract notes, create tag + Release |
| `verify` | Poll the proxy, then install into a throwaway module and assert `marketdata.Version()` |

Only a manual `workflow_dispatch` reaches it, and it also requires typing `RELEASE`.

## Notable choices

- **`tests.yml` gains `workflow_call`** so the gate *calls* the suite rather than copying it. A second copy would drift. Its checkouts take an optional `ref`, which renders empty — and therefore unchanged — for `push`/`pull_request`/`release`.
- **The module-path check is Go-specific and load-bearing.** Module `.../sdk-go/v2` can only ever publish `v2.x.y`. Dispatching `3.0.0` against it would otherwise cut a tag the import path cannot serve.
- **`verify` replaces the publish stage.** Before a tag exists `Version()` returns `unknown`, so asserting it from a scratch module proves the *published* module, not the checkout.
- **The `release: published` trigger in `tests.yml` stays silent** for an automated release — GitHub suppresses runs from `GITHUB_TOKEN`-raised events. That is fine and documented: `gate` already ran that suite against the same commit.
- **`CHANGELOG.md` gains `## [Unreleased]`** so the documented promote-then-release flow works as written.

## Verification

- `actionlint` clean on both workflows (it shellchecks the `run:` blocks).
- Module-path check: accepts `v2.0.1`/`v1.2.0`/`v3.1.4` against matching paths, rejects the three mismatches.
- CHANGELOG extractor: finds 2.0.0 (453 lines), finds nothing for 2.0.1, does not prefix-match `2.0`, excludes the link-reference block.
- Verify logic rehearsed against the real published v2.0.0 — resolved from the proxy, `Version()` asserted, and confirmed it genuinely fails on a wrong version.
- Build, 20 test packages and lint all pass.

The workflow itself has never run. Per the runbook, it should be exercised on a real `v2.0.1` — a release workflow that has never run is what fails the first time it matters.