### PR TITLE
docs: add the bug report and security reporting templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,180 @@
+name: Bug Report
+description: Report a bug in the Market Data Go SDK
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill out all required fields so we can reproduce and fix it quickly.
+
+        **Note:** This SDK returns data exactly as the API provides it. Before reporting, please confirm the behavior differs from what the [API documentation](https://www.marketdata.app/docs/api) describes (not just something unexpected to you).
+
+        Known differences between the API and its documentation are tracked in `integration/discrepancy_test.go`; it is worth a look before filing.
+
+  - type: checkboxes
+    id: api-docs-verified
+    attributes:
+      label: API documentation verification
+      options:
+        - label: I have reviewed the [API documentation](https://www.marketdata.app/docs/api) for this endpoint
+          required: true
+        - label: The behavior I'm reporting differs from what the API documentation describes
+          required: true
+
+  - type: dropdown
+    id: resource
+    attributes:
+      label: SDK resource
+      description: Which part of the SDK is affected?
+      options:
+        - stocks
+        - options
+        - funds
+        - markets
+        - utilities
+        - Client / configuration options
+        - Errors / error types
+        - Response formats (CSV, JSON, SaveToFile)
+        - Logging / diagnostics
+        - Rate limiting / retries
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: method
+    attributes:
+      label: Method
+      description: Which method are you calling? (for example Stocks.Candles, Options.Chain, Markets.StatusHistory)
+      placeholder: Stocks.Candles
+    validations:
+      required: true
+
+  - type: dropdown
+    id: call-style
+    attributes:
+      label: Which call style?
+      description: The SDK offers both for every endpoint.
+      options:
+        - "Context-first: client.Stocks.Quote(ctx, \"AAPL\") returning (T, *Response, error)"
+        - "Convenience wrapper: client.Stocks.GetQuote(\"AAPL\") returning (T, error)"
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction code
+      description: Complete, self-contained Go that demonstrates the bug. Ideally a `main.go` we can `go run`.
+      render: go
+      placeholder: |
+        package main
+
+        import (
+        	"context"
+        	"fmt"
+        	"log"
+
+        	"github.com/MarketDataApp/sdk-go/v2/marketdata"
+        )
+
+        func main() {
+        	client, err := marketdata.NewClient(marketdata.WithToken("..."))
+        	if err != nil {
+        		log.Fatal(err)
+        	}
+        	defer client.Close()
+
+        	candles, resp, err := client.Stocks.Candles(context.Background(), "AAPL")
+        	if err != nil {
+        		log.Fatal(err)
+        	}
+        	fmt.Println(len(candles), resp.StatusCode)
+        	// Bug: ...
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happens? Include exact values, and the full error text or panic stack trace.
+      placeholder: |
+        marketdata: bad request: countback must be positive (request_id=...)
+    validations:
+      required: true
+
+  - type: textarea
+    id: support-info
+    attributes:
+      label: Support info (if the SDK returned an error)
+      description: |
+        API-produced errors carry a support block. Print it with `fmt.Println(apiErr.SupportInfo())` after an `errors.As` into the error type you got. It contains the request id, URL, status code and timestamp we need for triage. Your API token is never included.
+      render: text
+      placeholder: |
+        --- MARKET DATA SUPPORT INFO ---
+        request_id:     8a1b2c3d4e5f6g7h-SJC
+        request_url:    https://api.marketdata.app/v1/stocks/candles/daily/AAPL/
+        status_code:    422
+        timestamp:      2026-09-02 12:00:00
+        message:        ...
+        exception_type: BadRequestError
+        --------------------------------
+    validations:
+      required: false
+
+  - type: input
+    id: sdk-version
+    attributes:
+      label: SDK version
+      description: |
+        The version in your `go.mod`, or run `fmt.Println(marketdata.Version())`. For example `v2.0.0`.
+      placeholder: "v2.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      description: Run `go version`. The SDK requires Go 1.22 or later.
+      placeholder: "go1.24.4"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: GOOS / GOARCH
+      description: Run `go env GOOS GOARCH`
+      placeholder: "linux amd64"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: sanity
+    attributes:
+      label: Before you file
+      options:
+        - label: I am using the `/v2` import path (`github.com/MarketDataApp/sdk-go/v2`), not the v1 module
+          required: false
+        - label: I can still reproduce this on the latest released version
+          required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Any other relevant information (client options in use, workarounds tried, whether it is intermittent, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  # Discussions are not enabled on this repository, so there is deliberately no
+  # "ask a question" link here — it would lead to a dead page. Questions go to
+  # the dashboard or Discord below.
+  - name: Report a security issue
+    url: https://github.com/MarketDataApp/sdk-go/security/policy
+    about: Learn how to privately report a security vulnerability (do not open a public issue)
+  - name: Market Data support & community
+    url: https://www.marketdata.app/dashboard/
+    about: "Account, billing, and API questions. Community chat: https://discord.com/invite/GmdeAVRtnT"
+  - name: API documentation
+    url: https://www.marketdata.app/docs/api
+    about: Endpoint reference — check here before filing an SDK bug, since the SDK returns what the API sends

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,172 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**This is a public repository. Do not open a public GitHub issue for a security
+vulnerability** — that discloses it to everyone before a fix is available.
+
+Instead, report privately through GitHub's **Private Vulnerability Reporting**:
+
+1. Go to the **Security** tab of this repository.
+2. Click **Report a vulnerability**.
+3. Describe the problem, including steps to reproduce, affected version(s), and
+   the impact.
+
+We will acknowledge the report, keep you informed as we investigate, and
+coordinate the disclosure timeline and a fixed release with you. Please give us
+a reasonable window to ship a fix before any public disclosure.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| `v2.x` (`github.com/MarketDataApp/sdk-go/v2`) | ✅ |
+| `v1.x` (`github.com/MarketDataApp/sdk-go`) | ❌ — superseded by v2; see `docs/MIGRATION.md` |
+
+## Scope
+
+This repo is the **Market Data Go SDK** — a client library that consumers add to
+their own Go modules. It runs on the consumer's machine or their servers, not on
+Market Data infrastructure. The security concerns that matter here are therefore
+about how the library treats *its consumers*:
+
+- **Credential handling** — the caller's API token must never be logged
+  verbatim, leaked in error messages, or written to disk. Tokens are redacted
+  (`redactToken`) and query strings are stripped from logged URLs
+  (`redactQuery`). Regressions here are in scope.
+- **Transport security** — TLS is validated by default and the SDK exposes no
+  skip-verify option. Anything that weakens this is in scope.
+- **Injection into outbound requests** — request building that lets caller input
+  smuggle headers, path segments, or query parameters it shouldn't. The configured
+  API version must be a single path segment for this reason — `/`, `\` and `..` are
+  rejected at client construction (`marketdata/config.go`).
+- **Decoding safety** — the `encoding/json` response path handling hostile or
+  malformed API responses without resource exhaustion, unbounded allocation, or
+  panics a consumer cannot defend against. Response size limits
+  (`ResponseTooLargeError`) are part of this.
+- **File output** — `SaveToFile` writing where the caller did not intend, or with
+  unsafe permissions.
+- **Supply-chain integrity of the published module** — the release pipeline
+  (`.github/workflows/tag-and-release.yml`) and the contents of the tagged tree.
+
+Out of scope:
+
+- **The Market Data API backend** itself. Report API/server vulnerabilities
+  through the API's own channel, not here.
+- **The `examples/` directory.** The TUI example apps (`stockterm`, `optionterm`,
+  `tuitest`) are separate modules with their own `go.mod` and their own
+  third-party dependencies. They are reference code, are never imported by the
+  SDK, and are not part of the published module.
+
+> **The published module has no third-party runtime dependencies.** It is built
+> entirely on the Go standard library, so there is no dependency tree to audit
+> and no transitive advisory surface. A vulnerability in the Go standard library
+> is fixed by upgrading your Go toolchain, not by a release here — though we will
+> raise the minimum Go version if a stdlib fix requires it. `govulncheck` runs on
+> every push and pull request and must be clean.
+
+## How this module is published
+
+Go has no package registry. `proxy.golang.org` reads the git tag directly, so
+**the tag is the publication**, and `sum.golang.org` records the module hash in a
+public transparency log.
+
+Two consequences matter for security:
+
+- **A published version cannot be withdrawn.** Deleting a tag on GitHub does not
+  remove the version from the proxy or the checksum database. If a release ever
+  ships a vulnerability, the fix is a *new* version, plus a `retract` directive in
+  `go.mod` so the toolchain stops selecting the bad one. The bad version stays
+  downloadable forever. See `.github/RELEASE_PROCESS.md` §6.
+- **The checksum database is a defence.** Because `sum.golang.org` pins the hash
+  of every version, a tag that is moved or a repository that is tampered with
+  after publication causes a verification failure on the consumer's machine
+  rather than a silent substitution. This is also why the `v1.2.0` tag must never
+  be moved or deleted.
+
+## Security Fix Policy
+
+This policy governs how security fixes are applied to this repository, including
+fixes made by automated agents (e.g. Claude Code) working in the repo. It sorts
+every security fix into one of two tiers.
+
+The dividing line for a **library** is *consumer compatibility*. A fix that any
+consumer can pick up by upgrading, with no source or behavior change on their
+side, is low-risk. A fix that forces consumers to change their code, recompile
+against a changed API, or adapt to changed runtime behavior is a breaking change
+and follows SemVer — those get the maintainer gate.
+
+### Tier 1 — Fix immediately (no approval needed)
+
+Security fixes that are **API- and behavior-compatible for legitimate
+consumers**. Existing callers keep compiling and keep working the same way after
+upgrading; only the vulnerability is closed.
+
+These may be fixed, tested, and committed right away. Every Tier 1 fix must be
+called out in its commit message, in `CHANGELOG.md`, and in the summary reported
+to the maintainer, so nothing ships silently.
+
+Typical Tier 1 fixes:
+
+- Tightening credential redaction, or plugging a token/secret/PII leak into logs
+  or error messages
+- Fixing injection in request building (header/path/query smuggling) where valid
+  caller input is unaffected
+- Hardening the response-decoding path against malformed or hostile API responses
+  (bounds, size limits, nil handling)
+- Correcting a logic flaw in an existing security check without changing its
+  public contract
+- Hardening `internal/` packages (transport, retry, rate limit, status cache,
+  dotenv) that consumers cannot import or depend on
+- Fixing the release pipeline or CI workflows
+
+### Tier 2 — Requires maintainer approval first
+
+Any security fix that **breaks consumer compatibility or changes observable
+runtime behavior**. These must NOT be applied unilaterally. The agent or
+contributor stops, writes up the issue, the proposed fix, and the specific
+consumer impact, and waits for the maintainer's approval before proceeding.
+
+A fix is **Tier 2** if it does any of the following:
+
+- Removes, renames, or changes the signature of any **exported** identifier in
+  `marketdata/...` (SemVer major)
+- **Adds a third-party dependency to the published module.** Being standard-library
+  only is a deliberate property of this SDK and a security property in its own
+  right; taking on a dependency is never an agent's call
+- Tightens input validation so that requests the SDK previously accepted are now
+  rejected (could break existing callers)
+- Changes a user-visible default (request or connect timeout, retry count or
+  backoff, rate-limit behavior, base URL, API version, startup validation,
+  `.env` loading)
+- Changes a response type's shape, or the error taxonomy that consumers match on
+  with `errors.Is` / `errors.As`
+- Changes a sealed union used for compile-time parameter exclusivity (ADR-017),
+  since that breaks callers at compile time
+- Raises the minimum Go version in `go.mod`
+- Changes the module path — which for Go means a new major version and a new
+  import path for every consumer
+
+### Classification rules
+
+- **When in doubt, it's Tier 2.** If it is unclear which tier a fix falls into,
+  treat it as Tier 2 and ask for approval.
+- **No urgency exception.** Even for a critical, actively-exploitable
+  vulnerability, a compatibility-breaking (Tier 2) fix waits for maintainer
+  approval. Flag the urgency loudly, propose the fix, and wait. The maintainer is
+  always the gate for changes that break consumers. (If a break is genuinely
+  unavoidable to close a critical hole, that's a maintainer decision about cutting
+  a major version — not an agent's.)
+
+### Release of security fixes
+
+Tiering governs *what* may be changed; the repo's normal release rules govern
+*what ships to consumers*. A Tier 1 fix may be committed to a branch and merged
+via the usual PR flow. **Cutting the tag that publishes it** — running
+`tag-and-release.yml` — requires explicit maintainer confirmation, exactly like
+every other release. Automated agents never cut or publish a release on their
+own.
+
+This matters more in Go than elsewhere: there is no staging feed and no unlist.
+The moment the tag exists and one person fetches it, the version is public and
+permanent.


### PR DESCRIPTION
**Answer to "do we have these?": no.** `sdk-go` was the only SDK with neither a bug template nor a security policy.

| File | csharp | java | js | php | **go (before)** |
|---|---|---|---|---|---|
| `.github/ISSUE_TEMPLATE/bug.yml` | ✅ | ✅ | ✅ | ✅ | ❌ |
| `.github/ISSUE_TEMPLATE/config.yml` | ✅ | ✅ | ✅ | ✅ | ❌ |
| `SECURITY.md` | ✅ | ✅ | ✅ | ✅ | ❌ |
| Private Vulnerability Reporting | ✅ | ✅ | ✅ | — | ❌ |

This adds the three files and **enables Private Vulnerability Reporting**, which was off — so until now the "Report a vulnerability" button the policy points at did not exist.

## Adapted, not copied

- **`bug.yml`** asks for `GOOS`/`GOARCH` and `go version` rather than a .NET runtime and TFM, offers the two call styles this SDK exposes (context-first vs the `Get*` wrappers), and points reporters at `SupportInfo()` — whose block is the same shape as the C# SDK's, so triage sees a familiar format.
- **`config.yml`** deliberately **omits the Discussions links** the C# and JS configs carry. Discussions are disabled on all of these repos, so those links currently lead to a dead page. This one links the security policy, the support dashboard and the API reference.
- **`SECURITY.md`** keeps the house two-tier fix policy verbatim in structure, restated for Go. The Go-specific Tier 2 entries are the interesting part: adding a third-party dependency to a standard-library-only module, changing a sealed union (ADR-017) that breaks callers at compile time, changing the error taxonomy consumers `errors.As` over, raising the minimum Go version, or changing the module path. It also documents what publishing means here — the tag is the publication, `sum.golang.org` makes it permanent, and `retract` is the only remedy.

## Verification

- Both YAML templates parse; 7 required fields, 5 block types.
- Every identifier the policy names exists in the tree: `redactToken`, `redactQuery`, `ResponseTooLargeError`, `SaveToFile`, `WithoutStartupValidation`, `WithoutDotEnv`.
- The path-traversal guard is real, but it lives in config validation rather than in `WithAPIVersion`; I confirmed the behaviour by running it (`../../etc`, `v1/x`, `v1\\x` all rejected at construction, `v1` accepted) and described it accordingly.

## Still missing versus the other repos

`BUG_FINDING.md` (a bug-hunting guide, ~15–24 KB), `ISSUE_WORKFLOW.md` (issue triage steps, ~14 KB), `dependabot.yml`, and `FUNDING.yml`. Not included here — say the word and I'll port them.