### PR TITLE
ci,docs: add Dependabot (grouped), FUNDING, and the bug-finding and issue workflows

### DIFF
--- a/.github/BUG_FINDING.md
+++ b/.github/BUG_FINDING.md
@@ -1,0 +1,543 @@
+# Bug Finding Workflow
+
+This document defines a systematic process for discovering bugs in
+`MarketDataApp/sdk-go` through exploration and testing, before users hit them.
+
+> **IMPORTANT: Every bug found MUST be submitted as a GitHub issue.**
+>
+> Do not just record bugs in markdown files, notes, or comments. Each bug must become a
+> real GitHub issue:
+>
+> - **CLI**: `gh issue create --label "bug" --title "[Bug]: ..." --body "..."`
+> - **Web**: [Create Bug Report](https://github.com/MarketDataApp/sdk-go/issues/new?template=bug.yml)
+>
+> A bug hunt is not complete until every discovered bug exists as a GitHub issue.
+
+## Overview
+
+**Purpose**: proactive bug discovery, as opposed to reactive bug processing.
+
+- **BUG_FINDING.md** (this document): find bugs before users encounter them.
+- **[ISSUE_WORKFLOW.md](./ISSUE_WORKFLOW.md)**: process bug reports that users submit.
+
+**Workflow**: Find Bug → **Create GitHub Issue (REQUIRED)** → [ISSUE_WORKFLOW.md] → Fix
+
+**When to use this document**:
+
+- QA passes before releases
+- Pre-release validation (see [RELEASE_PROCESS.md](./RELEASE_PROCESS.md))
+- Exploratory testing sessions
+- After a significant refactor
+- When onboarding, to understand the edge cases
+
+---
+
+## Prerequisites
+
+### Environment setup
+
+```bash
+go build ./...
+go version                # 1.22 or later; CI runs 1.22 and stable
+
+export MARKETDATA_TOKEN="your_token_here"
+```
+
+### Baseline verification
+
+Confirm the suite passes before hunting. Bug finding assumes a working baseline.
+
+```bash
+go test -race -p 1 ./...
+```
+
+> Run the race suite **sequentially** (`-p 1`). Running it in parallel across several
+> sessions has previously exhausted memory on developer machines.
+
+If tests fail, fix that first.
+
+### Architecture
+
+Familiarize yourself with the main components:
+
+- `marketdata.Client` — entry point, from `marketdata.NewClient(opts...)`. Exposes
+  `Stocks`, `Options`, `Funds`, `Markets`, `Utilities`. There is no global client and no
+  `init()` side effect; the caller owns it and calls `Close()`.
+- `internal/http` — transport, retries, the cached `/status/` retry gate, rate-limit
+  reservations, response-size limits.
+- The configuration cascade — `.env` < environment < client options < method parameters.
+  **The method wins.**
+- `*Response` — `Body`, `NoData`, `StatusCode`, `IsJSON`/`IsCSV`/`IsHTML`, `SaveToFile`,
+  `String`.
+- The error taxonomy in `marketdata/errors.go` — `AuthenticationError`,
+  `BadRequestError`, `NotFoundError`, `RateLimitError`, `ServerError`, `NetworkError`,
+  `ParseError`, `ValidationError`, `ResponseTooLargeError`, and more, each with a
+  matching `Err*` sentinel. All of them satisfy the `marketdata.Error` interface, which
+  is what exposes `Retryable()` and `SupportInfo()`.
+- The sealed date-window union — `OnDate`, `Between`, `Since`, `Until`, `LastN`,
+  `LastNUntil`, re-exported by each service package (`stocks.LastN(30)`,
+  `funds.Between(a, b)`). It lives in `internal/params`, so callers reach it only
+  through those aliases. Only one window can be supplied, and that is enforced at
+  compile time (ADR-017).
+
+### Two toolchains, always
+
+`go.mod` declares `go 1.22`, and CI runs the suite on **1.22 and stable**. A bug that
+appears on only one is still a bug, and is often a more interesting one. When a finding
+looks toolchain-dependent, record which you observed it on.
+
+```bash
+GOTOOLCHAIN=go1.22.12 go test ./...
+go test ./...
+```
+
+### Known differences, already tracked
+
+Before filing anything involving live data, read `integration/discrepancy_test.go`.
+Several API-vs-documentation differences are recorded there with links to the API's own
+issue tracker. Re-reporting one of those wastes a cycle; finding a *new* one is valuable.
+
+---
+
+## Area 1: Error Handling and the Error Taxonomy
+
+### What can go wrong
+
+- The wrong error type for a given HTTP status
+- `SupportInfo()` missing the request id or URL, making triage impossible
+- An API token leaking into a message, a log line, or `SupportInfo()`
+- A wrapped cause lost, so `errors.Is`/`errors.As` stop matching
+- `ParseError` returned for a payload the SDK should handle
+- An error that is genuinely retryable reporting `Retryable() == false`, or the reverse
+
+### Test scenarios
+
+#### 1.1 Bad token
+
+```go
+client, err := marketdata.NewClient(marketdata.WithToken("obviously-invalid-token"))
+// Verify: an *AuthenticationError, and the token does NOT appear in err.Error().
+// Bug indicator: a bare error string, or the token echoed back in any output.
+```
+
+#### 1.2 Unknown symbol
+
+```go
+q, resp, err := client.Stocks.Quote(ctx, "ZZZZQQ")
+// Verify: a *NotFoundError. The SDK deliberately reports an unknown symbol as
+// NotFoundError rather than as a successful empty answer.
+// Bug indicator: err == nil with resp.NoData true, or a nil-pointer panic on q.
+```
+
+#### 1.3 SupportInfo completeness
+
+```go
+_, _, err := client.Stocks.Candles(ctx, "AAPL", stocks.WithCandleWindow(stocks.LastN(-5)))
+
+// marketdata.Error is the interface every SDK error implements; it is what
+// carries SupportInfo(). Do NOT reach for *marketdata.APIError here — that is
+// one specific error (HTTP said OK, the body said otherwise), not a base type.
+var mdErr marketdata.Error
+if errors.As(err, &mdErr) {
+	fmt.Println(mdErr.SupportInfo())
+	// Verify: request_id, request_url, status_code, timestamp, message and
+	// exception_type all present, in that order, column-aligned.
+	// Bug indicator: blank values, missing lines, or a token in request_url.
+}
+```
+
+#### 1.4 errors.Is / errors.As discipline
+
+```go
+// Every typed error should match both its concrete type and its sentinel.
+var authErr *marketdata.AuthenticationError
+errors.As(err, &authErr)              // want true
+errors.Is(err, marketdata.ErrAuthentication) // want true
+// Bug indicator: one works and the other does not, or Unwrap() drops the cause.
+```
+
+### Red flags
+
+- A raw `*url.Error` or `*http.Response` reaching the caller
+- An API token visible anywhere in output, including DEBUG logs
+- `SupportInfo()` lines missing or unaligned
+- A wrapped cause dropped where an underlying failure clearly existed
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Bad token | `*AuthenticationError`, token redacted | Generic error, or token leaked |
+| Unknown symbol | `*NotFoundError`, consistently | Nil-pointer panic, or a silent empty success |
+| SupportInfo | All six fields present and aligned | Blank or missing fields |
+| Is/As | Both match, cause preserved | Either fails, or `Unwrap()` returns nil |
+
+---
+
+## Area 2: Empty and Sparse Responses
+
+This area has the worst track record in the repo's history. Treat it as the highest-yield
+place to look.
+
+### What can go wrong
+
+- A nil slice or nil pointer returned where an empty value is documented
+- `NoData` disagreeing with what was actually returned
+- A caller trusting `resp.NoData` (as the docs instruct) and then dereferencing nil
+- The API omitting an array the decoder assumes is present
+- A no-data chunk poisoning a merged multi-part response
+
+### Test scenarios
+
+#### 2.1 Empty result window
+
+```go
+// A valid question with an empty answer — a market holiday, or a window before listing.
+candles, resp, err := client.Stocks.Candles(ctx, "AAPL",
+	stocks.WithCandleWindow(stocks.OnDate(someMarketHoliday)))
+// Verify: err == nil, resp.NoData == true, candles is empty and NOT nil.
+// Bug indicator: a nil slice a range would silently skip, or a nil pointer.
+```
+
+#### 2.2 Empty list on a pointer-returning method
+
+```go
+exp, resp, err := client.Options.Expirations(ctx, "AAPL")
+// Verify: on a 200 with an empty list, exp is non-nil with an empty Dates slice.
+// The documented contract is "nil only on 404". A caller following the docs and
+// checking resp.NoData instead of exp != nil must not panic.
+```
+
+#### 2.3 Missing optional fields
+
+```go
+// Sparse rows: a field the API omits entirely, versus one it sends as null.
+// Verify: a null numeric stays distinguishable from a real 0 where the type
+// allows it (earnings EPS is the precedent), and an absent array decodes to
+// empty rather than panicking.
+```
+
+#### 2.4 Multi-part merge with a no-data part
+
+```go
+// A window wide enough to be split into chunks, where one chunk has no data.
+candles, _, err := client.Stocks.Candles(ctx, "AAPL",
+	stocks.WithCandleWindow(stocks.Between(longAgo, today)))
+// Verify: the no-data chunk is dropped, not merged in as empty rows, and the
+// surviving chunks are contiguous with no duplicated boundary day.
+```
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Empty window | `NoData` true, empty non-nil result | Nil slice or pointer |
+| Empty list | Non-nil with empty slice | Nil, panicking a docs-following caller |
+| Sparse fields | Null and zero stay distinct | Both collapse to zero |
+| Merged parts | Contiguous, no duplicates | Duplicated boundary rows |
+
+---
+
+## Area 3: Concurrency, Rate Limits, and Composite Requests
+
+### What can go wrong
+
+- Rate-limit metadata from one request observed on another
+- A retry consuming no reservation, so the limiter under-counts
+- A reservation leaked when a request panics or is cancelled
+- A cancelled fan-out reporting a deadline error as the root cause
+- Chunk boundaries overlapping, duplicating rows
+
+### Test scenarios
+
+#### 3.1 Rate-limit metadata is request-scoped
+
+```go
+// Fire many requests concurrently; read resp.RateLimit on each.
+// Verify: each response carries ITS OWN remaining count, not a shared latest value.
+// Bug indicator: all responses reporting the same number.
+```
+
+#### 3.2 Reservation accounting across retries
+
+```go
+// Force a retryable 5xx so the SDK retries.
+// Verify: every attempt reserves a credit, not just the first call, and the
+// response's remaining count is recorded before the reservation is released.
+// Bug indicator: the tracker drifting from the API's own header over a run.
+```
+
+#### 3.3 Cancellation during a fan-out
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+// Cancel mid-flight during a multi-symbol call.
+// Verify: the FIRST real error is what surfaces, not a downstream deadline
+// error from a sibling request; cancellations log at DEBUG, not ERROR.
+```
+
+#### 3.4 Close() under concurrency
+
+```go
+// Call Close() while requests are in flight, and with a caller-injected
+// WithHTTPClient transport.
+// Verify: no panic, and the caller's own transport is never reached into —
+// the SDK must not close idle connections it does not own.
+```
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Rate-limit scope | Per-response values | One shared value |
+| Retry accounting | One reservation per attempt | One per call |
+| Cancellation | First error surfaces, DEBUG log | Deadline error masks the cause, ERROR spam |
+| Close | Clean, caller's transport untouched | Panic, or caller's pool disturbed |
+
+---
+
+## Area 4: Date, Time, and Number Handling
+
+### What can go wrong
+
+- A timestamp rendered in the host timezone rather than US/Eastern
+- A null timestamp becoming the Unix epoch instead of the zero time
+- A wire fraction (`0.052`) displayed as a percentage without conversion, or twice
+- A countback window returning n+1 rows because the anchor is inclusive
+- A year or DST boundary off by one day
+
+### Test scenarios
+
+#### 4.1 Host timezone independence
+
+```bash
+TZ=Australia/Sydney go test ./...
+TZ=UTC              go test ./...
+TZ=America/New_York go test ./...
+# Verify: identical results. The SDK normalizes to US/Eastern and embeds tzdata,
+# so it must not read the host zone.
+```
+
+#### 4.2 Date format round-trip
+
+```go
+// Compare the same call with the default format and with WithDateFormat.
+// Verify: the same instants, differently rendered — not different instants.
+```
+
+#### 4.3 Null timestamp
+
+```go
+// A row whose timestamp the API sends as null.
+// Verify: the zero time.Time, and t.IsZero() == true.
+// Bug indicator: 1970-01-01, which is indistinguishable from a real epoch value.
+```
+
+#### 4.4 Countback row counts
+
+```go
+c, _, _ := client.Stocks.Candles(ctx, "AAPL", stocks.WithCandleWindow(stocks.LastN(5)))
+// Verify: exactly 5 rows.
+// Note: markets/status countback returning n+1 is a KNOWN API-side defect,
+// already tracked. Anywhere else, n+1 is a new bug.
+```
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Host timezone | Identical under any `TZ` | Results shift with the host |
+| Format round-trip | Same instants | Different instants |
+| Null timestamp | Zero time, `IsZero()` | Unix epoch |
+| Countback | Exactly n | n+1, or n-1 |
+
+---
+
+## Area 5: Configuration Cascade
+
+### What can go wrong
+
+- A `.env` value overriding a real environment variable
+- A client option ignored when a method parameter is absent, or the reverse
+- An explicitly-empty environment variable falling back to `.env`
+- An environment variable documented but never read
+
+### Test scenarios
+
+#### 5.1 Method beats client
+
+```go
+client, _ := marketdata.NewClient(
+	marketdata.WithToken(tok), marketdata.WithDateFormat("timestamp"))
+// Pass a different date format at the method level.
+// Verify: the method's value wins.
+```
+
+#### 5.2 Environment beats .env
+
+```bash
+# With a .env containing MARKETDATA_TOKEN=from_dotenv
+MARKETDATA_TOKEN=from_env go run .
+# Verify: from_env wins. A .env must never override a real environment variable.
+```
+
+#### 5.3 An explicitly empty variable is honored
+
+```bash
+MARKETDATA_TOKEN= go run .
+# Verify: the empty value is respected (the CI pattern for forcing demo mode)
+# and does NOT silently fall back to a .env file's value.
+```
+
+#### 5.4 WithoutDotEnv
+
+```go
+marketdata.NewClient(marketdata.WithToken(tok), marketdata.WithoutDotEnv())
+// Verify: no .env file is read at all.
+```
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Method vs client | Method wins | Client wins, or method ignored |
+| Env vs .env | Env wins | `.env` overrides a real variable |
+| Empty env var | Honored as empty | Falls back to `.env` |
+| `WithoutDotEnv` | No file read | `.env` still consulted |
+
+---
+
+## Area 6: Output Formats and File Export
+
+### What can go wrong
+
+- `IsJSON`/`IsCSV` disagreeing with the actual body
+- A CSV facet forcing a parameter the caller did not ask for
+- The columns projection dropping the field a row count keys off
+- `SaveToFile` writing outside the intended path, or with unsafe permissions
+- `String()` dumping an entire body where a summary is intended
+
+### Test scenarios
+
+#### 6.1 Format detection
+
+```go
+csvResp, err := client.Stocks.AsCSV().Candles(ctx, "AAPL")
+// Verify: resp.IsCSV() true, IsJSON() false, and Body parses as CSV.
+// Bug indicator: format flags set from the request rather than the response.
+```
+
+#### 6.2 Columns projection
+
+```go
+client, _ := marketdata.NewClient(marketdata.WithToken(tok),
+	marketdata.WithColumns("close"))
+// Verify: the SDK still requests whatever column it needs to count rows, and
+// the decoded result is coherent rather than silently empty.
+```
+
+#### 6.3 SaveToFile
+
+```go
+_, resp, _ := client.Stocks.Candles(ctx, "AAPL")
+err := resp.SaveToFile("/tmp/out.csv")
+// Verify: the file lands exactly where asked, with sane permissions, and a
+// path the caller did not intend is not reachable via the extension logic.
+```
+
+#### 6.4 The HTML facet stays unexported
+
+```go
+// ADR-018: HTML is built but deliberately NOT public, because the API does not
+// support format=html yet.
+// Bug indicator: an exported AsHTML() appearing on any service.
+```
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Format detection | Flags match the body | Flags reflect the request |
+| Columns | Coherent result | Silently empty rows |
+| SaveToFile | Intended path, sane perms | Escapes the path, or world-writable |
+| HTML facet | Unexported | Publicly reachable |
+
+---
+
+## Area 7: Compile-Time Exclusivity
+
+Go-specific, and the counterpart to the C# SDK's dependency-injection area. ADR-017 makes
+mutually-exclusive parameters single sealed-union values, so illegal combinations do not
+compile.
+
+### What can go wrong
+
+- A new option accepting a combination that should be impossible
+- The negative-compile corpus asserting a *different* failure than the one intended
+- A legal combination accidentally made to fail
+
+### Test scenarios
+
+#### 7.1 The corpus still holds
+
+```bash
+go test ./internal/negcompile/...
+# Verify: every negative case fails to build, every positive case builds, and
+# each negative case's expected message names the identifier it is about.
+```
+
+#### 7.2 A new option
+
+```go
+// After adding any option, ask: does it duplicate something an existing sealed
+// union already covers? If a caller could supply both, it belongs in the union,
+// not alongside it — and the corpus needs a new negative case.
+```
+
+### Pass/fail criteria
+
+| Scenario | Pass | Fail |
+|---|---|---|
+| Corpus | All negatives fail, positives build | A negative compiles |
+| New option | Folded into a union, corpus extended | Two options can conflict at runtime |
+
+---
+
+## Reporting What You Find
+
+For every bug, open an issue immediately. Include:
+
+1. The area and scenario number from this document
+2. Minimal reproduction code, complete with the `import` block and `NewClient`
+3. Expected versus actual behavior
+4. The `SupportInfo()` block when an error was involved
+5. SDK version, `go version`, and `go env GOOS GOARCH`
+6. Whether it reproduces on Go 1.22, on stable, or on both
+
+```bash
+gh issue create --label "bug" \
+  --title "[Bug]: Candles returns a nil slice for an empty window" \
+  --body "$(cat <<'EOF'
+**Area**: 2.1 Empty result window
+**Reproduces on**: go1.22.12 and stable
+...
+EOF
+)"
+```
+
+Then hand off to [ISSUE_WORKFLOW.md](./ISSUE_WORKFLOW.md).
+
+---
+
+## Coverage Note
+
+This repo enforces **100% statement coverage** of `marketdata/...` and `internal/...`, so
+every code path already has *a* test. That is exactly why this document targets behavior
+rather than reachability: full coverage proves each line ran, not that it did the right
+thing.
+
+The bugs left to find here are wrong answers on covered lines, disagreements between the
+two toolchain legs, assumptions about the host environment, and — most often in this
+repo's history — the difference between "no data" and "nil". Note also that coverage is
+scoped to the SDK packages: `examples/` is exercised by its own tests and the cross-app
+method guard, not by the gate.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: MarketDataApp

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -119,7 +119,16 @@ body:
     attributes:
       label: Support info (if the SDK returned an error)
       description: |
-        API-produced errors carry a support block. Print it with `fmt.Println(apiErr.SupportInfo())` after an `errors.As` into the error type you got. It contains the request id, URL, status code and timestamp we need for triage. Your API token is never included.
+        SDK errors carry a support block. Print it with:
+
+        ```go
+        var mdErr marketdata.Error
+        if errors.As(err, &mdErr) {
+            fmt.Println(mdErr.SupportInfo())
+        }
+        ```
+
+        It contains the request id, URL, status code and timestamp we need for triage. Your API token is never included.
       render: text
       placeholder: |
         --- MARKET DATA SUPPORT INFO ---

--- a/.github/ISSUE_WORKFLOW.md
+++ b/.github/ISSUE_WORKFLOW.md
@@ -1,0 +1,428 @@
+# Issue Workflow
+
+This document defines the process for triaging and resolving bug reports in
+`MarketDataApp/sdk-go`. It is written to be followed by a maintainer, human or
+automated.
+
+Companion document: [BUG_FINDING.md](./BUG_FINDING.md) finds bugs proactively. This
+document processes bugs that users report.
+
+## Overview
+
+```
+Verify Permissions → New Issue → Validate → [Valid]      → Reproduce → Accept → Fix → Close
+                                          → [Needs Info] → Request Info → Wait 7 days → Close
+                                          → [Not a Bug]  → Explain → Close
+```
+
+---
+
+## Step 0: Verify permissions
+
+Before processing issues, confirm you can manage them.
+
+```bash
+gh api repos/MarketDataApp/sdk-go/collaborators/$(gh api user --jq '.login')/permission --jq '.permission'
+```
+
+| Result | Meaning | Action |
+|---|---|---|
+| `admin`, `maintain`, `write`, `triage` | Sufficient permission | Go to Step 1 |
+| `read` | Read-only access | Stop. Ask a maintainer to elevate your access |
+| Error: `404 Not Found` | Not a collaborator | Stop. You cannot manage issues |
+| Error: `401 Unauthorized` | Not authenticated | Run `gh auth login` first |
+
+Quick check — exits 0 when you can manage issues:
+
+```bash
+gh api repos/MarketDataApp/sdk-go/collaborators/$(gh api user --jq '.login')/permission --jq '.permission' \
+  | grep -qE '^(admin|maintain|write|triage)$'
+```
+
+---
+
+## Step 1: Validate the bug report
+
+Run this checklist against every new report. The fields map directly to
+[`ISSUE_TEMPLATE/bug.yml`](./ISSUE_TEMPLATE/bug.yml).
+
+| # | Criterion | How to check | Pass | Fail |
+|---|---|---|---|---|
+| 1 | **API docs verified** | "API documentation verification" checkboxes | Both checked | Either unchecked |
+| 2 | **Has reproduction code** | "Reproduction code" field | A real Go code block | Empty, pseudocode, or prose only |
+| 3 | **Code is complete** | Look for client construction | Has `marketdata.NewClient(...)` plus the `import` block | Missing client setup or imports |
+| 4 | **Names the resource and method** | "SDK resource" + "Method" | Both present, e.g. `stocks` / `Stocks.Candles` | Empty or vague |
+| 5 | **Specifies SDK version** | "SDK version" | A concrete version, e.g. `v2.0.0` | Empty or "latest" |
+| 6 | **Specifies Go version** | "Go version" | A concrete version, e.g. `go1.24.4` | Empty or vague, e.g. "1.x" |
+| 7 | **Describes expected behavior** | "Expected behavior" | A clear statement | Empty or unclear |
+| 8 | **Describes actual behavior** | "Actual behavior" | A clear statement, ideally with the error text or panic trace | Empty or unclear |
+
+**Bonus signal, not required:** the "Support info" field. When the SDK returned an
+API-produced error, the `SupportInfo()` block carries `request_id`, `request_url`,
+`status_code` and `timestamp`. That identifies the exact upstream request and usually
+settles whether the fault is in the SDK or the API. Ask for it whenever an error is
+involved and the block is missing.
+
+**Check the import path first.** A surprising share of reports are really "I am on v1".
+If the reproduction imports `github.com/MarketDataApp/sdk-go` without `/v2`, they are
+using the v1 SDK, whose API is entirely different. Point them at `docs/MIGRATION.md`.
+
+### Decision
+
+- **All 8 pass** → Step 2 (Reproduce)
+- **Any fail** → Step 4 (Request more information)
+
+---
+
+## Step 2: Reproduce the bug
+
+1. Create a scratch module, or add a test alongside the affected package.
+
+   ```bash
+   cd "$(mktemp -d)" && go mod init repro
+   go get github.com/MarketDataApp/sdk-go/v2@vX.Y.Z   # the reported version
+   ```
+
+2. Use the reported SDK version. `go get ...@vX.Y.Z` pins it exactly; do not test against
+   `main` and assume it matches.
+3. Run it and compare against the reported "Actual behavior".
+4. If it involves the live API, check `integration/discrepancy_test.go` first — several
+   API-vs-documentation differences are already tracked there with links to the API's own
+   issue tracker, and the answer may already be recorded.
+
+### Decision
+
+| Outcome | Next step |
+|---|---|
+| **Reproduces** — output matches the report | Step 3A (Accept) |
+| **Does not reproduce** — the code works | Step 3B (Cannot reproduce) |
+| **Different error** — fails, but not as reported | Step 4 (Request more information) |
+| **API error, not SDK error** — the API itself returns the error | Step 3C (Not an SDK bug) |
+| **Expected API behavior** — the SDK faithfully returns what the API sent | Step 3C (Not an SDK bug) |
+| **User error** — the reproduction code is wrong | Step 3C (Not an SDK bug) |
+
+> **Reproduces on Go 1.22 but not on stable (or the reverse)?** That is a real bug, not a
+> non-repro. CI runs both legs for exactly this reason. Record which toolchain is affected
+> and go to Step 3A.
+
+---
+
+## Step 3A: Accept as a bug
+
+1. Add the label `accepted`.
+2. Comment with the template below.
+3. Go to Step 5.
+
+```markdown
+Thanks for the detailed report. I've reproduced this.
+
+**Reproduction confirmed:**
+- SDK version: [version]
+- Go version: [version]
+- GOOS/GOARCH: [platform]
+- Behavior: [what you observed]
+
+Working on a fix.
+```
+
+---
+
+## Step 3B: Cannot reproduce
+
+1. Add the label `needs-info`.
+2. Comment with the template below.
+
+```markdown
+I wasn't able to reproduce this with the information provided.
+
+**My environment:**
+- SDK version: [version]
+- Go version: [version]
+- GOOS/GOARCH: [platform]
+
+**What I observed:**
+[What actually happened — worked correctly, different output, etc.]
+
+Could you provide:
+- [ ] The `SupportInfo()` block from the error — it contains the request id and URL we need, and never includes your API token
+- [ ] Your client options, and any `MARKETDATA_*` environment variables or `.env` file in play
+- [ ] The complete error text, or the full panic trace
+- [ ] The exact version from your `go.mod` and the output of `go version`
+
+I'll keep this open for 7 days for additional information.
+```
+
+---
+
+## Step 3C: Not an SDK bug
+
+1. Add the label `wontfix`.
+2. Comment with the applicable template.
+3. Close the issue.
+
+### API issue, not the SDK
+
+```markdown
+Thanks for the report. After investigation this is behavior of the Market Data API itself rather than the Go SDK.
+
+**What's happening:**
+[Explain the API behavior]
+
+**Suggested next steps:**
+- Check the [API documentation](https://www.marketdata.app/docs/api) for this endpoint
+- Contact Market Data support if you believe the API behavior is wrong
+- Join the [Discord](https://discord.com/invite/GmdeAVRtnT) for community help
+
+Closing as outside the SDK's scope. Please open a new issue if you find an SDK-specific problem.
+```
+
+### Expected API behavior
+
+```markdown
+Thanks for the report. After checking the [API documentation](https://www.marketdata.app/docs/api), this matches how the API is designed to work.
+
+**What you're seeing:**
+[Describe the behavior]
+
+**Documentation reference:**
+[Link or quote]
+
+The SDK returns data exactly as the API provides it. If you believe the documentation is wrong, or the API should behave differently, please contact Market Data support or join the [Discord](https://discord.com/invite/GmdeAVRtnT).
+
+Closing as working-as-designed.
+```
+
+### User error
+
+~~~markdown
+Thanks for the report. Reviewing the reproduction code, this looks like an issue in the calling code rather than a bug in the SDK.
+
+**The issue:**
+[Explain what's wrong]
+
+**Suggested fix:**
+```go
+// Corrected code
+```
+
+**Documentation reference:**
+[Link if applicable]
+
+Closing this, but reopen if you believe there is still an SDK bug.
+~~~
+
+### Wrong major version
+
+```markdown
+Thanks for the report. The reproduction imports `github.com/MarketDataApp/sdk-go`, which is the **v1** SDK. v2 lives at a different import path:
+
+```go
+import "github.com/MarketDataApp/sdk-go/v2/marketdata"
+```
+
+```bash
+go get github.com/MarketDataApp/sdk-go/v2
+```
+
+v2 is a complete rewrite — no global client, context on every method, typed errors. See [docs/MIGRATION.md](https://github.com/MarketDataApp/sdk-go/blob/main/docs/MIGRATION.md).
+
+Closing, but please reopen or file a new issue if the behavior persists on v2.
+```
+
+---
+
+## Step 4: Request more information
+
+1. Add the label `needs-info`.
+2. Comment, keeping only the items you actually need.
+3. Check back in 7 days.
+
+```markdown
+Thanks for the report. To investigate I need some additional information:
+
+- [ ] **API documentation verification**: Please confirm you've checked the [API documentation](https://www.marketdata.app/docs/api) and that the behavior differs from what it describes
+- [ ] **Complete reproduction code**: A self-contained Go program including the `import` block and `marketdata.NewClient(...)`
+- [ ] **Support info**: If the SDK returned an error, paste `SupportInfo()` — it carries the request id, URL, status code and timestamp, and never includes your API token
+- [ ] **SDK version**: The version in your `go.mod`, or the output of `marketdata.Version()`
+- [ ] **Go version**: The output of `go version`
+- [ ] **Platform**: The output of `go env GOOS GOARCH`
+- [ ] **Expected behavior**: What did you expect?
+- [ ] **Actual behavior**: What happened? Include the full error text or panic trace
+- [ ] **Additional context**: [Specify]
+
+I'll keep this open for 7 days. Without a response I'll close it, but you're always welcome to reopen with the details.
+```
+
+### 7-day follow-up
+
+```markdown
+Closing due to inactivity. If you can provide the requested information, feel free to reopen or open a new issue with the additional details.
+```
+
+---
+
+## Step 5: Fix the bug
+
+1. [ ] **Write a failing test** next to the affected package and confirm it fails. Unit
+       tests serve all HTTP from an `httptest.Server` — they never reach the network.
+2. [ ] **Implement the minimal fix.**
+3. [ ] **Confirm the new test passes.**
+4. [ ] **Run the full suite and the coverage gate.** This repo requires **100% statement
+       coverage** of `marketdata/...` and `internal/...`; CI fails below it.
+
+       ```bash
+       go test -race -p 1 ./...
+       go test -race -p 1 -coverprofile=cov.out ./marketdata/... ./internal/...
+       go tool cover -func=cov.out | tail -1        # must read 100.0%
+       ```
+
+       > Run the race suite **sequentially** (`-p 1`). Running it in parallel across
+       > several sessions has previously exhausted memory on developer machines.
+
+5. [ ] **Check the minimum toolchain still builds**: `GOTOOLCHAIN=go1.22.12 go test ./...`.
+6. [ ] **Check formatting and lint**: `gofmt -l .` (must print nothing) and
+       `golangci-lint run`. Use the pinned release binary — see the note in
+       `.github/workflows/tests.yml`; a locally built golangci-lint links against a
+       different toolchain and reports phantom stdlib errors.
+7. [ ] **If the fix changes an illegal parameter combination**, extend the corpus in
+       `internal/negcompile/testdata/` so the combination is asserted not to compile.
+8. [ ] **If the fix touches live-API behavior**, run the integration suite:
+
+       ```bash
+       MARKETDATA_TOKEN=... go test ./integration/... -tags=integration -count=1
+       ```
+
+9. [ ] **Add a CHANGELOG entry** under `## [Unreleased]`.
+10. [ ] **Commit** as `fix: description (closes #NNN)`.
+11. [ ] **Open a PR** against `main`. Integration tests run on every PR.
+
+Examples:
+
+- `fix(stocks): decode BulkCandles when the API omits the symbol array (closes #45)`
+- `fix(options): return an empty Expirations rather than nil on an empty list (closes #67)`
+
+---
+
+## Step 6: Close the issue
+
+1. GitHub auto-closes from a `closes #NNN` commit message once merged.
+2. If it did not, close it by hand with a comment.
+
+~~~markdown
+Fixed in [commit or PR link].
+
+This ships in the next release. To use it immediately, point your module at `main` with a `replace` directive:
+
+```
+replace github.com/MarketDataApp/sdk-go/v2 => github.com/MarketDataApp/sdk-go/v2 main
+```
+
+or pin the pseudo-version:
+
+```bash
+go get github.com/MarketDataApp/sdk-go/v2@main
+```
+~~~
+
+---
+
+## Labels reference
+
+| Label | Meaning | When to apply |
+|---|---|---|
+| `bug` | Default label from the template | Automatic on new issues |
+| `accepted` | Validated and reproduced | After successful reproduction |
+| `needs-info` | Waiting on the reporter | Report incomplete, or cannot reproduce |
+| `wontfix` | Not a bug, or will not be fixed | When closing as not-a-bug |
+| `dependencies` | Dependency update | Automatic on Dependabot PRs |
+
+---
+
+## CLI reference
+
+```bash
+# Labels
+gh issue edit NUMBER --add-label "accepted"
+gh issue edit NUMBER --add-label "needs-info"
+gh issue edit NUMBER --remove-label "bug"
+
+# State
+gh issue close NUMBER
+gh issue reopen NUMBER
+
+# Comment and inspect
+gh issue comment NUMBER --body "Comment text here"
+gh issue view NUMBER
+
+# Lists
+gh issue list --label "bug"
+gh issue list --label "needs-info"
+```
+
+---
+
+## Examples
+
+### Example A: valid bug report
+
+**Issue #42** — resource `stocks`, method `Stocks.Candles`, complete reproduction code
+with imports and `NewClient`, expected "returns candle data", actual "panic: runtime
+error: invalid memory address", SDK `v2.0.0`, Go `go1.24.4`.
+
+**Action:** passes all criteria → reproduce → accept and fix.
+
+---
+
+### Example B: incomplete report
+
+**Issue #43** — resource `options`, method `Options.Chain`, reproduction code reads "I
+called the chain method and it broke", expected "it should work", actual "it doesn't
+work", SDK version empty, Go version "1.x".
+
+**Action:** fails criteria 2, 3, 5, 6, 7, 8 → request more information, naming each
+missing item.
+
+---
+
+### Example C: not a bug (API behavior)
+
+**Issue #44** — `stocks` / `Stocks.Quote`, complete code, expected "should return the
+after-hours price", actual "returns the regular session price".
+
+**Investigation:** the API returns regular-session prices by default.
+
+**Action:** close as "Not an SDK bug" with a pointer to the API documentation.
+
+---
+
+### Example D: expected API behavior
+
+**Issue #45** — `stocks` / `Stocks.Earnings`, complete code, expected "percentages like
+`5.2` for 5.2%", actual "returns `0.052`", both docs checkboxes checked.
+
+**Investigation:** the API documents percentage fields as decimals (`0.052` = 5.2%). The
+SDK passes the response through unchanged.
+
+**Action:** close as "Expected API behavior", quoting the documentation.
+
+---
+
+### Example E: wrong major version
+
+**Issue #46** — reproduction imports `github.com/MarketDataApp/sdk-go` and calls
+`api.StockQuote().Symbol("AAPL").Get(ctx)`, which no longer exists.
+
+**Investigation:** that is the v1 builder API. The reporter is on the v1 module.
+
+**Action:** close with the "Wrong major version" template and a link to
+`docs/MIGRATION.md`.
+
+---
+
+### Example F: toolchain-specific failure
+
+**Issue #47** — `stocks` / `Stocks.Candles`, reproduces on Go 1.22, works on Go 1.24.
+
+**Action:** this is a real bug. `go.mod` declares `go 1.22`, and CI runs that leg
+precisely so the floor keeps working. Accept it and write the regression test so it runs
+on both legs.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Everything here is grouped. Ungrouped, a single bubbletea bump would open one
+# PR per example module (three of them share the same charmbracelet and
+# golang.org/x dependency set), and each transitive bump would open three more.
+# One PR per ecosystem per week is the whole point.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    # The published SDK module is standard-library only, so "/" has nothing to
+    # update today — it is listed so that a dependency added later is managed
+    # from the start rather than silently unmanaged. The example apps are
+    # separate modules with real dependencies; the glob picks up new ones.
+    directories:
+      - "/"
+      - "/examples/*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+    groups:
+      # Routine bumps land as one reviewable PR.
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Majors are batched separately: they need reading, and they should not
+      # hold up the safe bumps above.
+      go-modules-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    ignore:
+      # Both are satisfied by a `replace` directive pointing at a local path, so
+      # the version recorded in the example go.mod files is inert. A Dependabot
+      # PR bumping them would change nothing and never be mergeable.
+      - dependency-name: "github.com/MarketDataApp/sdk-go/v2"
+      - dependency-name: "github.com/MarketDataApp/sdk-go/v2/examples/tuitest"


### PR DESCRIPTION
Completes community-file parity with sdk-csharp/-java/-js/-php. Ports the four remaining files, adapted to Go rather than search-and-replaced.

## `dependabot.yml` — everything grouped

The three example apps are **separate modules sharing one charmbracelet + golang.org/x dependency set**. Ungrouped, a single bubbletea bump opens three PRs, and every transitive bump three more.

- Minor/patch land as **one PR**; **majors batch separately**, so they get read without holding up the safe bumps.
- The two `replace`-directive self-references are ignored — a PR bumping them changes nothing and could never merge.
- The root module is listed even though it is standard-library only, so a dependency added later is managed from day one.

## `BUG_FINDING.md`

Seven areas grounded in **this repo's real defect history**, not the C# ones:

- **Area 2 (empty and sparse responses)** is flagged as the highest-yield place to look, because it is where this SDK has actually broken — nil vs empty on `Expirations`, the missing symbol array in `BulkCandles`, duplicated candle-chunk boundaries.
- **Area 7 is Go-specific**: the ADR-017 sealed unions and the `negcompile` corpus, replacing the C# dependency-injection area.
- Readers are pointed at `integration/discrepancy_test.go` first, so they stop re-reporting known API-side differences.

## `ISSUE_WORKFLOW.md`

Adds a triage path the other SDKs have no equivalent for: **wrong major version**. Importing `sdk-go` without `/v2` yields the v1 builder API, which will keep generating confused reports.

## Two corrections to the already-merged `bug.yml`

`*marketdata.APIError` is one *specific* error (HTTP said OK, body said otherwise), **not a base type** — `errors.As` into it does not reach a `NotFoundError`. `marketdata.Error` is the interface that actually carries `SupportInfo()`. Fixed in both `bug.yml` and `BUG_FINDING.md`.

## Labels

Created `accepted`, `needs-info` and `dependencies`, which both documents reference. They did not exist here — nor, as it happens, on sdk-csharp, whose `ISSUE_WORKFLOW.md` references them too.

## Verification

- All four YAML files parse; actionlint still clean; build and 20 test packages pass.
- Caller-facing window constructors corrected to the service-package aliases (`stocks.LastN`), since `internal/params` is not importable by users.
- Every cross-link and repo-relative path in both documents resolves.
- The unknown-symbol → `*NotFoundError`, `errors.Is(ErrNotFound)` and `errors.As(marketdata.Error)` claims were each confirmed by running them against the live API.